### PR TITLE
Changed from using internal class to more public class

### DIFF
--- a/booklist.scala
+++ b/booklist.scala
@@ -1,4 +1,4 @@
-import scala.collection.mutable.MutableList
+import scala.collection.mutable.ListBuffer
 import scala.util.Try
 import scala.io.Source
 
@@ -10,7 +10,7 @@ case class Book(title : String, author : String, year : Int)
 // Your job is to replace all ??? with your own code.
 
 class BookList {
-   var list = MutableList[Book]()
+   var list = ListBuffer[Book]()
 
    def addBook(book : Book) : Unit = {
       // write code to add the book to 'list'.
@@ -26,24 +26,24 @@ class BookList {
       // you should also show how to use the method in your main
    }
 
-   def getTitlesByAuthor(author : String) : MutableList[String] = {
-      val byAuthorList = MutableList[String]()
+   def getTitlesByAuthor(author : String) : ListBuffer[String] = {
+      val byAuthorList = ListBuffer[String]()
       // return a list of all titles that are written by author
 
 
       byAuthorList
    }
 
-   def getTitlesContaining(substring : String) : MutableList[String] = {
-      val titles = MutableList[String]()
+   def getTitlesContaining(substring : String) : ListBuffer[String] = {
+      val titles = ListBuffer[String]()
       // return a list of all titles that contain a substring
 
       titles
    }
 
-   def getBooksBetweenYears(firstYear : Int, lastYear : Int) : MutableList[Book] = {
+   def getBooksBetweenYears(firstYear : Int, lastYear : Int) : ListBuffer[Book] = {
      
-      val betweenYearList = MutableList[Book]()
+      val betweenYearList = ListBuffer[Book]()
       // get all books between two years
 
 


### PR DESCRIPTION
You used `MutableList` throughout this code initially. My initial issue with this is the fact that the scala documentation clearly states:

> This class is used internally to represent mutable lists. It is the basis for the implementation of the class Queue.

So it would seem to be, from a design perspective, that this shouldn't be used as it is here. My next issue with it (which after googling is a common issue) is that it isn't as full featured as, for example, `ListBuffer`. The first method that I see it lacking is the `remove(n: Int)` method which removes an element at the index `n`.

Even further for my case, the scala cookbook states to use the `ListBuffer` class as opposed to the `MutableList` class.
